### PR TITLE
Refactor api handler definitions

### DIFF
--- a/src/api/handler.go
+++ b/src/api/handler.go
@@ -56,8 +56,8 @@ func (h *handler) buildActions() {
 		"create":        gae_support.With(h.withAuth(h.create)),
 		"subscriptions": gae_support.With(h.withAuth(h.subscriptions)),
 
-		"show":          gae_support.With(h.withAuth(h.Identified(h.show))),
-		"destroy":       gae_support.With(h.withAuth(h.Identified(h.destroy))),
+		"show":    gae_support.With(h.withAuth(h.Identified(h.show))),
+		"destroy": gae_support.With(h.withAuth(h.Identified(h.destroy))),
 		// "build_task":    gae_support.With(h.withAuth(h.Identified(h.pipelineTask("build")))),
 		"close": gae_support.With(h.withAuth(h.Identified(h.callPipelineTask("close")))),
 		// "close_task":    gae_support.With(h.withAuth(h.Identified(h.pipelineTask("close")))),

--- a/src/api/handler.go
+++ b/src/api/handler.go
@@ -35,14 +35,13 @@ func Setup(echo *echo.Echo) {
 	g.Use(middleware.CORS())
 
 	g.GET("", h.Actions["index"])
+	g.POST("", h.Actions["create"])
 	g.GET("/subscriptions", h.Actions["subscriptions"])
+
 	g.GET("/:id", h.Actions["show"])
 	g.DELETE("/:id", h.Actions["destroy"])
-
-	g.POST("", h.Actions["create"])
 	// g.POST("/:id/build_task", h.Actions["build"])
 	g.POST("/:id/build_task", gae_support.With(h.withAuth(h.Identified(h.pipelineTask("build")))))
-
 	g.PUT("/:id/close", h.Actions["close"])
 	// g.POST("/:id/close_task", h.Actions["close_task"])
 	g.POST("/:id/close_task", gae_support.With(h.withAuth(h.Identified(h.pipelineTask("close")))))
@@ -54,13 +53,15 @@ func Setup(echo *echo.Echo) {
 func (h *handler) buildActions() {
 	h.Actions = map[string](func(c echo.Context) error){
 		"index":         gae_support.With(h.withAuth(h.index)),
+		"create":        gae_support.With(h.withAuth(h.create)),
 		"subscriptions": gae_support.With(h.withAuth(h.subscriptions)),
+
 		"show":          gae_support.With(h.withAuth(h.Identified(h.show))),
 		"destroy":       gae_support.With(h.withAuth(h.Identified(h.destroy))),
-		"create":        gae_support.With(h.withAuth(h.create)),
 		// "build_task":    gae_support.With(h.withAuth(h.Identified(h.pipelineTask("build")))),
 		"close": gae_support.With(h.withAuth(h.Identified(h.callPipelineTask("close")))),
 		// "close_task":    gae_support.With(h.withAuth(h.Identified(h.pipelineTask("close")))),
+
 		"refresh":      gae_support.With(h.refresh), // Don't use withAuth because this is called from cron
 		"refresh_task": gae_support.With(h.Identified(h.pipelineTask("refresh"))),
 	}

--- a/src/api/handler.go
+++ b/src/api/handler.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/appengine/taskqueue"
 )
 
-type handler struct{
+type handler struct {
 	Actions map[string](func(c echo.Context) error)
 }
 
@@ -51,16 +51,16 @@ func Setup(echo *echo.Echo) {
 
 func (h *handler) buildActions() {
 	h.Actions = map[string](func(c echo.Context) error){
-		"index": h.withAuth(h.index),
+		"index":         h.withAuth(h.index),
 		"subscriptions": h.withAuth(h.subscriptions),
-		"show" : h.withAuth(h.Identified(h.show)),
-		"destroy": h.withAuth(h.Identified(h.destroy)),
-		"create": h.withAuth(h.create),
-		"build_task": h.withAuth(h.pipelineTask("build")),
-		"close": h.callPipelineTask("close"),
-		"close_task": h.withAuth(h.pipelineTask("close")),
-		"refresh": gae_support.With(h.refresh), // Don't use withAuth because this is called from cron
-		"refresh_task": gae_support.With(h.pipelineTask("refresh")),
+		"show":          h.withAuth(h.Identified(h.show)),
+		"destroy":       h.withAuth(h.Identified(h.destroy)),
+		"create":        h.withAuth(h.create),
+		"build_task":    h.withAuth(h.pipelineTask("build")),
+		"close":         h.callPipelineTask("close"),
+		"close_task":    h.withAuth(h.pipelineTask("close")),
+		"refresh":       gae_support.With(h.refresh), // Don't use withAuth because this is called from cron
+		"refresh_task":  gae_support.With(h.pipelineTask("refresh")),
 	}
 }
 

--- a/src/api/handler.go
+++ b/src/api/handler.go
@@ -40,10 +40,12 @@ func Setup(echo *echo.Echo) {
 	g.DELETE("/:id", h.Actions["destroy"])
 
 	g.POST("", h.Actions["create"])
-	g.POST("/:id/build_task", h.Actions["build"])
+	// g.POST("/:id/build_task", h.Actions["build"])
+	g.POST("/:id/build_task", gae_support.With(h.withAuth(h.Identified(h.pipelineTask("build")))))
 
 	g.PUT("/:id/close", h.Actions["close"])
-	g.POST("/:id/close_task", h.Actions["close_task"])
+	// g.POST("/:id/close_task", h.Actions["close_task"])
+	g.POST("/:id/close_task", gae_support.With(h.withAuth(h.Identified(h.pipelineTask("close")))))
 
 	g.GET("/refresh", h.Actions["refresh"])
 	g.POST("/:id/refresh_task", h.Actions["refresh_task"])
@@ -56,9 +58,9 @@ func (h *handler) buildActions() {
 		"show":          gae_support.With(h.withAuth(h.Identified(h.show))),
 		"destroy":       gae_support.With(h.withAuth(h.Identified(h.destroy))),
 		"create":        gae_support.With(h.withAuth(h.create)),
-		"build_task":    gae_support.With(h.withAuth(h.Identified(h.pipelineTask("build")))),
+		// "build_task":    gae_support.With(h.withAuth(h.Identified(h.pipelineTask("build")))),
 		"close":         gae_support.With(h.withAuth(h.Identified(h.callPipelineTask("close")))),
-		"close_task":    gae_support.With(h.withAuth(h.Identified(h.pipelineTask("close")))),
+		// "close_task":    gae_support.With(h.withAuth(h.Identified(h.pipelineTask("close")))),
 		"refresh":       gae_support.With(h.refresh), // Don't use withAuth because this is called from cron
 		"refresh_task":  gae_support.With(h.Identified(h.pipelineTask("refresh"))),
 	}

--- a/src/api/handler.go
+++ b/src/api/handler.go
@@ -37,13 +37,13 @@ func Setup(echo *echo.Echo) {
 	g.DELETE("/:id", h.Identified(h.withAuth, h.destroy))
 
 	g.POST("", h.withAuth(h.create))
-	g.POST("/:id/build_task", h.pipelineTask("build"))
+	g.POST("/:id/build_task", h.pipelineTask(h.withAuth, "build"))
 
 	g.PUT("/:id/close", h.callPipelineTask("close"))
-	g.POST("/:id/close_task", h.pipelineTask("close"))
+	g.POST("/:id/close_task", h.pipelineTask(h.withAuth, "close"))
 
 	g.GET("/refresh", gae_support.With(h.refresh)) // Don't use withAuth because this is called from cron
-	g.POST("/:id/refresh_task", h.pipelineTask("refresh"))
+	g.POST("/:id/refresh_task", h.pipelineTask(gae_support.With, "refresh"))
 }
 
 func (h *handler) withAuth(impl func(c echo.Context) error) func(c echo.Context) error {
@@ -102,14 +102,7 @@ func (h *handler) callPipelineTask(action string) func(c echo.Context) error {
 // curl -v -X POST http://localhost:8080/pipelines/1/build_task
 // curl -v -X	POST http://localhost:8080/pipelines/1/close_task
 // curl -v -X	POST http://localhost:8080/pipelines/1/refresh_task
-func (h *handler) pipelineTask(action string) func(c echo.Context) error {
-	var wrapper func(impl func(c echo.Context) error) func(c echo.Context) error
-	switch action {
-	case "refresh":
-		wrapper = gae_support.With
-	default:
-		wrapper = h.withAuth
-	}
+func (h *handler) pipelineTask(wrapper func(impl func(c echo.Context) error) func(c echo.Context) error, action string) func(c echo.Context) error {
 	return h.Identified(wrapper, func(c echo.Context, pl *models.Pipeline) error {
 		ctx := c.Get("aecontext").(context.Context)
 		err := pl.Process(ctx, action)

--- a/src/api/handler.go
+++ b/src/api/handler.go
@@ -57,7 +57,7 @@ func (h *handler) buildActions() {
 		"destroy":       gae_support.With(h.withAuth(h.Identified(h.destroy))),
 		"create":        gae_support.With(h.withAuth(h.create)),
 		"build_task":    gae_support.With(h.withAuth(h.pipelineTask("build"))),
-		"close":         h.callPipelineTask("close"),
+		"close":         gae_support.With(h.withAuth(h.Identified(h.callPipelineTask("close")))),
 		"close_task":    gae_support.With(h.withAuth(h.pipelineTask("close"))),
 		"refresh":       gae_support.With(h.refresh), // Don't use withAuth because this is called from cron
 		"refresh_task":  gae_support.With(h.pipelineTask("refresh")),
@@ -102,8 +102,8 @@ func (h *handler) Identified(impl func(c echo.Context, pl *models.Pipeline) erro
 }
 
 // curl -v -X PUT http://localhost:8080/pipelines/1/close
-func (h *handler) callPipelineTask(action string) func(c echo.Context) error {
-	return gae_support.With(h.withAuth(h.Identified(func(c echo.Context, pl *models.Pipeline) error {
+func (h *handler) callPipelineTask(action string) func(c echo.Context, pl *models.Pipeline) error {
+	return func(c echo.Context, pl *models.Pipeline) error {
 		id := c.Param("id")
 		ctx := c.Get("aecontext").(context.Context)
 		req := c.Request()
@@ -113,7 +113,7 @@ func (h *handler) callPipelineTask(action string) func(c echo.Context) error {
 			return err
 		}
 		return c.JSON(http.StatusCreated, pl)
-	})))
+	}
 }
 
 // curl -v -X POST http://localhost:8080/pipelines/1/build_task

--- a/src/api/handler.go
+++ b/src/api/handler.go
@@ -59,10 +59,10 @@ func (h *handler) buildActions() {
 		"destroy":       gae_support.With(h.withAuth(h.Identified(h.destroy))),
 		"create":        gae_support.With(h.withAuth(h.create)),
 		// "build_task":    gae_support.With(h.withAuth(h.Identified(h.pipelineTask("build")))),
-		"close":         gae_support.With(h.withAuth(h.Identified(h.callPipelineTask("close")))),
+		"close": gae_support.With(h.withAuth(h.Identified(h.callPipelineTask("close")))),
 		// "close_task":    gae_support.With(h.withAuth(h.Identified(h.pipelineTask("close")))),
-		"refresh":       gae_support.With(h.refresh), // Don't use withAuth because this is called from cron
-		"refresh_task":  gae_support.With(h.Identified(h.pipelineTask("refresh"))),
+		"refresh":      gae_support.With(h.refresh), // Don't use withAuth because this is called from cron
+		"refresh_task": gae_support.With(h.Identified(h.pipelineTask("refresh"))),
 	}
 }
 

--- a/src/api/handler_test.go
+++ b/src/api/handler_test.go
@@ -120,7 +120,7 @@ func TestActions(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(pl.ID)
 
-	f = h.Identified(h.withAuth, h.show)
+	f = h.withAuth(h.Identified(h.show))
 	if assert.NoError(t, f(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -275,7 +275,7 @@ func TestActions(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(pl.ID)
 
-	f = h.Identified(h.withAuth, h.destroy)
+	f = h.withAuth(h.Identified(h.destroy))
 	if assert.NoError(t, f(c)) {
 		assert.Equal(t, http.StatusNotAcceptable, rec.Code) // http.StatusUnprocessableEntity
 		s := rec.Body.String()
@@ -301,7 +301,7 @@ func TestActions(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(pl.ID)
 
-	f = h.Identified(h.withAuth, h.destroy)
+	f = h.withAuth(h.Identified(h.destroy))
 	if assert.NoError(t, f(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -324,7 +324,7 @@ func TestActions(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(pl.ID)
 
-	f = h.Identified(h.withAuth, h.show)
+	f = h.withAuth(h.Identified(h.show))
 	if assert.NoError(t, f(c)) {
 		assert.Equal(t, http.StatusNotFound, rec.Code)
 	}

--- a/src/api/handler_test.go
+++ b/src/api/handler_test.go
@@ -120,7 +120,7 @@ func TestActions(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(pl.ID)
 
-	f = h.withPipeline(h.withAuth, h.show)
+	f = h.Identified(h.withAuth, h.show)
 	if assert.NoError(t, f(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -275,7 +275,7 @@ func TestActions(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(pl.ID)
 
-	f = h.withPipeline(h.withAuth, h.destroy)
+	f = h.Identified(h.withAuth, h.destroy)
 	if assert.NoError(t, f(c)) {
 		assert.Equal(t, http.StatusNotAcceptable, rec.Code) // http.StatusUnprocessableEntity
 		s := rec.Body.String()
@@ -301,7 +301,7 @@ func TestActions(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(pl.ID)
 
-	f = h.withPipeline(h.withAuth, h.destroy)
+	f = h.Identified(h.withAuth, h.destroy)
 	if assert.NoError(t, f(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -324,7 +324,7 @@ func TestActions(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(pl.ID)
 
-	f = h.withPipeline(h.withAuth, h.show)
+	f = h.Identified(h.withAuth, h.show)
 	if assert.NoError(t, f(c)) {
 		assert.Equal(t, http.StatusNotFound, rec.Code)
 	}


### PR DESCRIPTION
- Define `buildActions` in `api.handler` struct
    - Use built actions in test
- Use Context.Get/Set instead of passing as argument

## Attention

It's good to use `buildActions` but it causes [critical error](https://github.com/groovenauts/blocks-concurrent-batch-agent/pull/35/commits/69d7d101eb90b9813f4bb2c79189036105e8d4c5) with taskqueue ( except `refresh_task`... why? ).

So `buildActions` doesn't treat `build_task` and `close_task`.

