### PR TITLE
Install glide with apt on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ sudo: false
 language: go
 go:
   - 1.6.3
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:masterminds/glide'
+    packages:
+      - glide
 before_install:
   ## Install App Engine SDK for Go
   - curl -o $HOME/go_appengine_sdk_linux_amd64.zip https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.48.zip
@@ -9,10 +15,8 @@ before_install:
   - unzip -q -x $HOME/go_appengine_sdk_linux_amd64.zip -d $HOME
   - PATH=$PATH:$HOME/go_appengine
   - goapp version
-  ## Install glide
   - test -d $GOPATH/bin || mkdir -p $GOPATH/bin
   - make checksetup
-  - curl https://glide.sh/get | sh
 install:
   ## Install dependencies
   - make glide_install


### PR DESCRIPTION
I don't know the reason, but the tests frequently fail in Travis CI like https://travis-ci.org/groovenauts/blocks-concurrent-batch-agent/builds/260149547 .
This PR modifies `.travis.yml` to install `glide` with `apt` instead of `curl https://glide.sh/get | sh` .

This works well, see https://travis-ci.org/groovenauts/blocks-concurrent-batch-agent/builds/260158002?utm_source=github_status&utm_medium=notification .