### PR TITLE
Refactorings to prepare to add hibernation feature

### DIFF
--- a/src/api/job_handler.go
+++ b/src/api/job_handler.go
@@ -30,14 +30,13 @@ func (h *JobHandler) member(action echo.HandlerFunc) echo.HandlerFunc {
 // curl -v -X POST http://localhost:8080/pipelines/3/jobs --data '{"id":"2","name":"akm"}' -H 'Content-Type: application/json'
 func (h *JobHandler) create(c echo.Context) error {
 	ctx := c.Get("aecontext").(context.Context)
-	req := c.Request()
+	pl := c.Get("pipeline").(*models.Pipeline)
 	job := &models.Job{}
 	if err := c.Bind(job); err != nil {
 		log.Errorf(ctx, "err: %v\n", err)
-		log.Errorf(ctx, "req: %v\n", req)
+		log.Errorf(ctx, "req: %v\n", c.Request())
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
-	pl := c.Get("pipeline").(*models.Pipeline)
 	job.Pipeline = pl
 	job.InitStatus(c.QueryParam("ready") == "true")
 	err := job.CreateAndPublishIfPossible(ctx)

--- a/src/api/pipeline_handler.go
+++ b/src/api/pipeline_handler.go
@@ -400,11 +400,15 @@ func (h *PipelineHandler) PostPipelineTaskWith(c echo.Context, action string, pl
 	return nil
 }
 
-func (h *PipelineHandler) PostPipelineTaskWithETA(c echo.Context, action string, pl *models.Pipeline, eta time.Time) error {
-	err := h.PostPipelineTaskWith(c, action, pl, url.Values{}, func(t *taskqueue.Task) error {
+func (h *PipelineHandler) SetETAFunc(eta time.Time) func(t *taskqueue.Task) error {
+	return func(t *taskqueue.Task) error {
 		t.ETA = eta
 		return nil
-	})
+	}
+}
+
+func (h *PipelineHandler) PostPipelineTaskWithETA(c echo.Context, action string, pl *models.Pipeline, eta time.Time) error {
+	err := h.PostPipelineTaskWith(c, action, pl, url.Values{}, h.SetETAFunc(eta))
 	if err != nil {
 		return err
 	}

--- a/src/api/pipeline_handler.go
+++ b/src/api/pipeline_handler.go
@@ -68,7 +68,7 @@ func (h *PipelineHandler) PostPipelineTaskIfPossible(c echo.Context, pl *models.
 		if pl.Dryrun {
 			log.Debugf(ctx, "[DRYRUN] POST buildTask for %v\n", pl)
 		} else {
-			err := h.PostPipelineTaskWith(c, "build_task", pl, url.Values{}, nil)
+			err := PostPipelineTaskWith(c, "build_task", pl, url.Values{}, nil)
 			if err != nil {
 				return err
 			}
@@ -109,8 +109,8 @@ func (h *PipelineHandler) cancel(c echo.Context) error {
 		// Wait until deploying is finished
 		return c.JSON(http.StatusAccepted, pl)
 	case models.Opened:
-		return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-			return h.PostPipelineTask(c, "close_task", pl)
+		return ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+			return PostPipelineTask(c, "close_task", pl)
 		})
 	case models.Closing, models.ClosingError, models.Closed:
 		// Do nothing because it's already closed or being closed
@@ -141,8 +141,8 @@ func (h *PipelineHandler) destroy(c echo.Context) error {
 // curl -v -X POST http://localhost:8080/pipelines/:id/refresh
 func (h *PipelineHandler) refresh(c echo.Context) error {
 	pl := c.Get("pipeline").(*models.Pipeline)
-	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-		return h.PostPipelineTask(c, "refresh_task", pl)
+	return ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+		return PostPipelineTask(c, "refresh_task", pl)
 	})
 }
 
@@ -154,8 +154,8 @@ func (h *PipelineHandler) publishTask(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-		return h.PostPipelineTask(c, "subscribe_task", pl)
+	return ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+		return PostPipelineTask(c, "subscribe_task", pl)
 	})
 }
 
@@ -165,7 +165,7 @@ func (h *PipelineHandler) refreshTask(c echo.Context) error {
 	pl := c.Get("pipeline").(*models.Pipeline)
 	refresher := &models.Refresher{}
 	err := refresher.Process(ctx, pl, pl.RefreshHandler(ctx, func(pl *models.Pipeline) error {
-		return h.PostPipelineTaskWith(c, "build_task", pl, url.Values{}, nil)
+		return PostPipelineTaskWith(c, "build_task", pl, url.Values{}, nil)
 	}))
 	if err != nil {
 		log.Errorf(ctx, "Failed to refresh pipeline %v because of %v\n", pl, err)

--- a/src/api/pipeline_handler.go
+++ b/src/api/pipeline_handler.go
@@ -186,7 +186,7 @@ func (h *PipelineHandler) waitBuildingTask(c echo.Context) error {
 
 	switch pl.Status {
 	case models.Deploying:
-		return h.PostPipelineTaskWithETA(c, "wait_building_task", pl, http.StatusAccepted, started.Add(30*time.Second))
+		return h.PostPipelineTaskWithETAReturnJSON(c, "wait_building_task", pl, http.StatusAccepted, started.Add(30*time.Second))
 	case models.Opened:
 		if pl.Cancelled {
 			return h.PostPipelineTask(c, "close_task", pl, http.StatusNoContent)
@@ -332,7 +332,7 @@ func (h *PipelineHandler) waitClosingTask(c echo.Context) error {
 
 	switch pl.Status {
 	case models.Closing:
-		return h.PostPipelineTaskWithETA(c, "wait_closing_task", pl, http.StatusAccepted, started.Add(30*time.Second))
+		return h.PostPipelineTaskWithETAReturnJSON(c, "wait_closing_task", pl, http.StatusAccepted, started.Add(30*time.Second))
 	case models.Closed:
 		return c.JSON(http.StatusOK, pl)
 	default:
@@ -374,10 +374,10 @@ func (h *PipelineHandler) PostPipelineTaskWith(c echo.Context, action string, pl
 }
 
 func (h *PipelineHandler) PostPipelineTask(c echo.Context, action string, pl *models.Pipeline, status int) error {
-	return h.PostPipelineTaskWithETA(c, action, pl, status, time.Now())
+	return h.PostPipelineTaskWithETAReturnJSON(c, action, pl, status, time.Now())
 }
 
-func (h *PipelineHandler) PostPipelineTaskWithETA(c echo.Context, action string, pl *models.Pipeline, status int, eta time.Time) error {
+func (h *PipelineHandler) PostPipelineTaskWithETAReturnJSON(c echo.Context, action string, pl *models.Pipeline, status int, eta time.Time) error {
 	err := h.PostPipelineTaskWith(c, action, pl, func(t *taskqueue.Task) error {
 		t.ETA = eta
 		return nil

--- a/src/api/pipeline_handler.go
+++ b/src/api/pipeline_handler.go
@@ -4,16 +4,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 
 	"gae_support"
 	"models"
 
 	"github.com/labstack/echo"
 	"golang.org/x/net/context"
-	"google.golang.org/api/googleapi"
 	"google.golang.org/appengine/log"
-	"google.golang.org/appengine/taskqueue"
 )
 
 type PipelineHandler struct {
@@ -149,70 +146,6 @@ func (h *PipelineHandler) refresh(c echo.Context) error {
 	})
 }
 
-// curl -v -X POST http://localhost:8080/pipelines/1/build_task
-func (h *PipelineHandler) buildTask(c echo.Context) error {
-	ctx := c.Get("aecontext").(context.Context)
-	pl := c.Get("pipeline").(*models.Pipeline)
-	builder, err := models.NewBuilder(ctx)
-	if err != nil {
-		return err
-	}
-	err = builder.Process(ctx, pl)
-	if err != nil {
-		switch err.(type) {
-		case *googleapi.Error:
-			e2 := err.(*googleapi.Error)
-			switch e2.Code {
-			case http.StatusConflict: // googleapi: Error 409: 'projects/optical-hangar-158902/global/deployments/pipeline-mjr-59-20170926-163820' already exists and cannot be created., duplicate
-				log.Warningf(ctx, "Skip building because of %v", e2.Message)
-				return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
-					return h.PostPipelineTask(c, "wait_building_task", pl)
-				})
-			}
-		}
-		log.Errorf(ctx, "Failed to build a pipeline %v because of %v\n", pl, err)
-		return err
-	}
-
-	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-		return h.PostPipelineTask(c, "wait_building_task", pl)
-	})
-}
-
-// curl -v -X	POST http://localhost:8080/pipelines/1/wait_building_task
-func (h *PipelineHandler) waitBuildingTask(c echo.Context) error {
-	started := time.Now()
-	ctx := c.Get("aecontext").(context.Context)
-	pl := c.Get("pipeline").(*models.Pipeline)
-
-	handler := pl.RefreshHandler(ctx)
-	refresher := &models.Refresher{}
-	err := refresher.Process(ctx, pl, handler)
-	if err != nil {
-		log.Errorf(ctx, "Failed to refresh pipeline %v because of %v\n", pl, err)
-		return err
-	}
-
-	switch pl.Status {
-	case models.Deploying:
-		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
-			return h.PostPipelineTaskWithETA(c, "wait_building_task", pl, started.Add(30*time.Second))
-		})
-	case models.Opened:
-		if pl.Cancelled {
-			return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
-				return h.PostPipelineTask(c, "close_task", pl)
-			})
-		} else {
-			return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-				return h.PostPipelineTask(c, "publish_task", pl)
-			})
-		}
-	default:
-		return &models.InvalidStateTransition{Msg: fmt.Sprintf("Unexpected Status: %v for Pipeline: %v", pl.Status, pl)}
-	}
-}
-
 // curl -v -X	POST http://localhost:8080/pipelines/1/publish_task
 func (h *PipelineHandler) publishTask(c echo.Context) error {
 	ctx := c.Get("aecontext").(context.Context)
@@ -224,147 +157,6 @@ func (h *PipelineHandler) publishTask(c echo.Context) error {
 	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
 		return h.PostPipelineTask(c, "subscribe_task", pl)
 	})
-}
-
-// curl -v -X	POST http://localhost:8080/pipelines/1/subscribe_task
-func (h *PipelineHandler) subscribeTask(c echo.Context) error {
-	started := time.Now()
-	ctx := c.Get("aecontext").(context.Context)
-	pl := c.Get("pipeline").(*models.Pipeline)
-
-	if pl.Cancelled {
-		switch pl.Status {
-		case models.Opened:
-			log.Infof(ctx, "Pipeline is cancelled.\n")
-			return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
-				return h.PostPipelineTask(c, "close_task", pl)
-			})
-		case models.Closing, models.ClosingError, models.Closed:
-			log.Warningf(ctx, "Pipeline is cancelled but do nothing because it's already closed or being closed.\n")
-			return c.JSON(http.StatusOK, pl)
-		default:
-			return &models.InvalidStateTransition{
-				Msg: fmt.Sprintf("Invalid Pipeline#Status %v to subscribe a Pipeline cancelled", pl.Status),
-			}
-		}
-	}
-
-	err := pl.PullAndUpdateJobStatus(ctx)
-	if err != nil {
-		switch err.(type) {
-		case *models.SubscriprionNotFound:
-			switch pl.Status {
-			case models.Closing, models.Closed:
-				log.Infof(ctx, "Pipeline is already closed\n")
-				return c.JSON(http.StatusOK, pl)
-			default:
-				log.Infof(ctx, "Subscription is not found but the pipeline isn't closed because of %v\n", err)
-			}
-		default:
-			log.Errorf(ctx, "Failed to get Pipeline#PullAndUpdateJobStatus() because of %v\n", err)
-			return err
-		}
-	}
-
-	jobs, err := pl.JobAccessor().All(ctx)
-	if err != nil {
-		log.Errorf(ctx, "Failed to m.JobAccessor#All() because of %v\n", err)
-		return err
-	}
-	log.Debugf(ctx, "Pipeline has %v jobs\n", len(jobs))
-
-	pendings, err := models.GlobalPipelineAccessor.PendingsFor(ctx, jobs.Finished().IDs())
-	if err != nil {
-		return err
-	}
-
-	for _, pending := range pendings {
-		org := c.Get("organization").(*models.Organization)
-		pending.Organization = org
-		err := pending.UpdateIfReserveOrWait(ctx)
-		if err != nil {
-			log.Errorf(ctx, "Failed to UpdateIfReserveOrWait pending: %v\n%v\n", pending, err)
-			return err
-		}
-		if pending.Status == models.Reserved {
-			err = h.PostPipelineTaskIfPossible(c, pending)
-			if err != nil {
-				log.Errorf(ctx, "Failed to PostPipelineTaskIfPossible pending: %v\n%v\n", pending, err)
-				return err
-			}
-		}
-	}
-
-	if jobs.AllFinished() {
-		if pl.ClosePolicy.Match(jobs) {
-			return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-				return h.PostPipelineTask(c, "close_task", pl)
-			})
-		} else {
-			return c.JSON(http.StatusOK, pl)
-		}
-	} else {
-		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
-			return h.PostPipelineTaskWithETA(c, "subscribe_task", pl, started.Add(30*time.Second))
-		})
-	}
-}
-
-// curl -v -X	POST http://localhost:8080/pipelines/1/close_task
-func (h *PipelineHandler) closeTask(c echo.Context) error {
-	ctx := c.Get("aecontext").(context.Context)
-	pl := c.Get("pipeline").(*models.Pipeline)
-	closer, err := models.NewCloser(ctx)
-	if err != nil {
-		log.Errorf(ctx, "Failed to create new closer because of %v\n", err)
-		return err
-	}
-	err = closer.Process(ctx, pl)
-	if err != nil {
-		switch err.(type) {
-		case *googleapi.Error:
-			e2 := err.(*googleapi.Error)
-			switch e2.Code {
-			case http.StatusNotFound: // googleapi: Error 404: The object 'projects/optical-hangar-158902/global/deployments/pipeline-mjr-89-20170926-223541' is not found., notFound
-				log.Warningf(ctx, "Skip closing because of %v", e2.Message)
-				return c.JSON(http.StatusOK, pl)
-			}
-		}
-		log.Errorf(ctx, "Failed to close pipeline because of %v\n", err)
-		return err
-	}
-
-	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-		return h.PostPipelineTask(c, "wait_closing_task", pl)
-	})
-}
-
-// curl -v -X	POST http://localhost:8080/pipelines/1/wait_closing_task
-func (h *PipelineHandler) waitClosingTask(c echo.Context) error {
-	started := time.Now()
-	ctx := c.Get("aecontext").(context.Context)
-	pl := c.Get("pipeline").(*models.Pipeline)
-	handler := pl.RefreshHandlerWith(ctx, func(pl *models.Pipeline) error {
-		return h.PostPipelineTaskWith(c, "build_task", pl, url.Values{}, nil)
-	})
-
-	refresher := &models.Refresher{}
-	err := refresher.Process(ctx, pl, handler)
-	if err != nil {
-		log.Errorf(ctx, "Failed to refresh pipeline %v because of %v\n", pl, err)
-		return err
-	}
-
-	switch pl.Status {
-	case models.Closing:
-		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
-			return h.PostPipelineTaskWithETA(c, "wait_closing_task", pl, started.Add(30*time.Second))
-		})
-	case models.Closed:
-		return c.JSON(http.StatusOK, pl)
-	default:
-		return &models.InvalidStateTransition{Msg: fmt.Sprintf("Unexpected Status: %v for Pipeline: %v", pl.Status, pl)}
-	}
 }
 
 // curl -v -X	POST http://localhost:8080/pipelines/1/refresh_task
@@ -380,49 +172,4 @@ func (h *PipelineHandler) refreshTask(c echo.Context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, pl)
-}
-
-func (h *PipelineHandler) PostPipelineTaskWith(c echo.Context, action string, pl *models.Pipeline, params url.Values, f func(*taskqueue.Task) error) error {
-	ctx := c.Get("aecontext").(context.Context)
-	req := c.Request()
-	t := taskqueue.NewPOSTTask(fmt.Sprintf("/pipelines/%s/%s", pl.ID, action), params)
-	t.Header.Add(AUTH_HEADER, req.Header.Get(AUTH_HEADER))
-	if f != nil {
-		err := f(t)
-		if err != nil {
-			return err
-		}
-	}
-	if _, err := taskqueue.Add(ctx, t, ""); err != nil {
-		log.Errorf(ctx, "Failed to add a task %v to taskqueue because of %v\n", t, err)
-		return err
-	}
-	return nil
-}
-
-func (h *PipelineHandler) SetETAFunc(eta time.Time) func(t *taskqueue.Task) error {
-	return func(t *taskqueue.Task) error {
-		t.ETA = eta
-		return nil
-	}
-}
-
-func (h *PipelineHandler) PostPipelineTaskWithETA(c echo.Context, action string, pl *models.Pipeline, eta time.Time) error {
-	err := h.PostPipelineTaskWith(c, action, pl, url.Values{}, h.SetETAFunc(eta))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (h *PipelineHandler) PostPipelineTask(c echo.Context, action string, pl *models.Pipeline) error {
-	return h.PostPipelineTaskWithETA(c, action, pl, time.Now())
-}
-
-func (h *PipelineHandler) ReturnJsonWith(c echo.Context, pl *models.Pipeline, status int, f func() error) error {
-	err := f()
-	if err != nil {
-		return err
-	}
-	return c.JSON(status, pl)
 }

--- a/src/api/pipeline_handler.go
+++ b/src/api/pipeline_handler.go
@@ -164,7 +164,7 @@ func (h *PipelineHandler) refreshTask(c echo.Context) error {
 	ctx := c.Get("aecontext").(context.Context)
 	pl := c.Get("pipeline").(*models.Pipeline)
 	refresher := &models.Refresher{}
-	err := refresher.Process(ctx, pl, pl.RefreshHandlerWith(ctx, func(pl *models.Pipeline) error {
+	err := refresher.Process(ctx, pl, pl.RefreshHandler(ctx, func(pl *models.Pipeline) error {
 		return h.PostPipelineTaskWith(c, "build_task", pl, url.Values{}, nil)
 	}))
 	if err != nil {

--- a/src/api/pipeline_handler.go
+++ b/src/api/pipeline_handler.go
@@ -111,7 +111,9 @@ func (h *PipelineHandler) cancel(c echo.Context) error {
 		// Wait until deploying is finished
 		return c.JSON(http.StatusAccepted, pl)
 	case models.Opened:
-		return h.PostPipelineTaskReturnJSON(c, "close_task", pl, http.StatusCreated)
+		return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+			return h.PostPipelineTask(c, "close_task", pl)
+		})
 	case models.Closing, models.ClosingError, models.Closed:
 		// Do nothing because it's already closed or being closed
 		return c.JSON(http.StatusNoContent, pl)
@@ -141,7 +143,9 @@ func (h *PipelineHandler) destroy(c echo.Context) error {
 // curl -v -X POST http://localhost:8080/pipelines/:id/refresh
 func (h *PipelineHandler) refresh(c echo.Context) error {
 	pl := c.Get("pipeline").(*models.Pipeline)
-	return h.PostPipelineTaskReturnJSON(c, "refresh_task", pl, http.StatusCreated)
+	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+		return h.PostPipelineTask(c, "refresh_task", pl)
+	})
 }
 
 // curl -v -X POST http://localhost:8080/pipelines/1/build_task
@@ -160,14 +164,18 @@ func (h *PipelineHandler) buildTask(c echo.Context) error {
 			switch e2.Code {
 			case http.StatusConflict: // googleapi: Error 409: 'projects/optical-hangar-158902/global/deployments/pipeline-mjr-59-20170926-163820' already exists and cannot be created., duplicate
 				log.Warningf(ctx, "Skip building because of %v", e2.Message)
-				return h.PostPipelineTaskReturnJSON(c, "wait_building_task", pl, http.StatusNoContent)
+				return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
+					return h.PostPipelineTask(c, "wait_building_task", pl)
+				})
 			}
 		}
 		log.Errorf(ctx, "Failed to build a pipeline %v because of %v\n", pl, err)
 		return err
 	}
 
-	return h.PostPipelineTaskReturnJSON(c, "wait_building_task", pl, http.StatusCreated)
+	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+		return h.PostPipelineTask(c, "wait_building_task", pl)
+	})
 }
 
 // curl -v -X	POST http://localhost:8080/pipelines/1/wait_building_task
@@ -186,12 +194,18 @@ func (h *PipelineHandler) waitBuildingTask(c echo.Context) error {
 
 	switch pl.Status {
 	case models.Deploying:
-		return h.PostPipelineTaskWithETAReturnJSON(c, "wait_building_task", pl, http.StatusAccepted, started.Add(30*time.Second))
+		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
+			return h.PostPipelineTaskWithETA(c, "wait_building_task", pl, started.Add(30*time.Second))
+		})
 	case models.Opened:
 		if pl.Cancelled {
-			return h.PostPipelineTaskReturnJSON(c, "close_task", pl, http.StatusNoContent)
+			return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
+				return h.PostPipelineTask(c, "close_task", pl)
+			})
 		} else {
-			return h.PostPipelineTaskReturnJSON(c, "publish_task", pl, http.StatusCreated)
+			return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+				return h.PostPipelineTask(c, "publish_task", pl)
+			})
 		}
 	default:
 		return &models.InvalidStateTransition{Msg: fmt.Sprintf("Unexpected Status: %v for Pipeline: %v", pl.Status, pl)}
@@ -206,7 +220,9 @@ func (h *PipelineHandler) publishTask(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return h.PostPipelineTaskReturnJSON(c, "subscribe_task", pl, http.StatusCreated)
+	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+		return h.PostPipelineTask(c, "subscribe_task", pl)
+	})
 }
 
 // curl -v -X	POST http://localhost:8080/pipelines/1/subscribe_task
@@ -219,7 +235,9 @@ func (h *PipelineHandler) subscribeTask(c echo.Context) error {
 		switch pl.Status {
 		case models.Opened:
 			log.Infof(ctx, "Pipeline is cancelled.\n")
-			return h.PostPipelineTaskReturnJSON(c, "close_task", pl, http.StatusNoContent)
+			return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
+				return h.PostPipelineTask(c, "close_task", pl)
+			})
 		case models.Closing, models.ClosingError, models.Closed:
 			log.Warningf(ctx, "Pipeline is cancelled but do nothing because it's already closed or being closed.\n")
 			return c.JSON(http.StatusOK, pl)
@@ -278,12 +296,16 @@ func (h *PipelineHandler) subscribeTask(c echo.Context) error {
 
 	if jobs.AllFinished() {
 		if pl.ClosePolicy.Match(jobs) {
-			return h.PostPipelineTask(c, "close_task", pl, http.StatusCreated)
+			return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+				return h.PostPipelineTask(c, "close_task", pl)
+			})
 		} else {
 			return c.JSON(http.StatusOK, pl)
 		}
 	} else {
-		return h.PostPipelineTaskWithETAReturnJSON(c, "subscribe_task", pl, http.StatusAccepted, started.Add(30*time.Second))
+		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
+			return h.PostPipelineTaskWithETA(c, "subscribe_task", pl, started.Add(30*time.Second))
+		})
 	}
 }
 
@@ -311,7 +333,9 @@ func (h *PipelineHandler) closeTask(c echo.Context) error {
 		return err
 	}
 
-	return h.PostPipelineTaskReturnJSON(c, "wait_closing_task", pl, http.StatusCreated)
+	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+		return h.PostPipelineTask(c, "wait_closing_task", pl)
+	})
 }
 
 // curl -v -X	POST http://localhost:8080/pipelines/1/wait_closing_task
@@ -332,7 +356,9 @@ func (h *PipelineHandler) waitClosingTask(c echo.Context) error {
 
 	switch pl.Status {
 	case models.Closing:
-		return h.PostPipelineTaskWithETAReturnJSON(c, "wait_closing_task", pl, http.StatusAccepted, started.Add(30*time.Second))
+		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
+			return h.PostPipelineTaskWithETA(c, "wait_closing_task", pl, started.Add(30*time.Second))
+		})
 	case models.Closed:
 		return c.JSON(http.StatusOK, pl)
 	default:
@@ -373,15 +399,23 @@ func (h *PipelineHandler) PostPipelineTaskWith(c echo.Context, action string, pl
 	return nil
 }
 
-func (h *PipelineHandler) PostPipelineTaskReturnJSON(c echo.Context, action string, pl *models.Pipeline, status int) error {
-	return h.PostPipelineTaskWithETAReturnJSON(c, action, pl, status, time.Now())
-}
-
-func (h *PipelineHandler) PostPipelineTaskWithETAReturnJSON(c echo.Context, action string, pl *models.Pipeline, status int, eta time.Time) error {
+func (h *PipelineHandler) PostPipelineTaskWithETA(c echo.Context, action string, pl *models.Pipeline, eta time.Time) error {
 	err := h.PostPipelineTaskWith(c, action, pl, func(t *taskqueue.Task) error {
 		t.ETA = eta
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *PipelineHandler) PostPipelineTask(c echo.Context, action string, pl *models.Pipeline) error {
+	return h.PostPipelineTaskWithETA(c, action, pl, time.Now())
+}
+
+func (h *PipelineHandler) ReturnJsonWith(c echo.Context, pl *models.Pipeline, status int, f func() error) error {
+	err := f()
 	if err != nil {
 		return err
 	}

--- a/src/api/pipeline_handler_build.go
+++ b/src/api/pipeline_handler_build.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"models"
+
+	"github.com/labstack/echo"
+	"golang.org/x/net/context"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/appengine/log"
+)
+
+// curl -v -X POST http://localhost:8080/pipelines/1/build_task
+func (h *PipelineHandler) buildTask(c echo.Context) error {
+	ctx := c.Get("aecontext").(context.Context)
+	pl := c.Get("pipeline").(*models.Pipeline)
+	builder, err := models.NewBuilder(ctx)
+	if err != nil {
+		return err
+	}
+	err = builder.Process(ctx, pl)
+	if err != nil {
+		switch err.(type) {
+		case *googleapi.Error:
+			e2 := err.(*googleapi.Error)
+			switch e2.Code {
+			case http.StatusConflict: // googleapi: Error 409: 'projects/optical-hangar-158902/global/deployments/pipeline-mjr-59-20170926-163820' already exists and cannot be created., duplicate
+				log.Warningf(ctx, "Skip building because of %v", e2.Message)
+				return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
+					return h.PostPipelineTask(c, "wait_building_task", pl)
+				})
+			}
+		}
+		log.Errorf(ctx, "Failed to build a pipeline %v because of %v\n", pl, err)
+		return err
+	}
+
+	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+		return h.PostPipelineTask(c, "wait_building_task", pl)
+	})
+}
+
+// curl -v -X	POST http://localhost:8080/pipelines/1/wait_building_task
+func (h *PipelineHandler) waitBuildingTask(c echo.Context) error {
+	started := time.Now()
+	ctx := c.Get("aecontext").(context.Context)
+	pl := c.Get("pipeline").(*models.Pipeline)
+
+	handler := pl.RefreshHandler(ctx)
+	refresher := &models.Refresher{}
+	err := refresher.Process(ctx, pl, handler)
+	if err != nil {
+		log.Errorf(ctx, "Failed to refresh pipeline %v because of %v\n", pl, err)
+		return err
+	}
+
+	switch pl.Status {
+	case models.Deploying:
+		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
+			return h.PostPipelineTaskWithETA(c, "wait_building_task", pl, started.Add(30*time.Second))
+		})
+	case models.Opened:
+		if pl.Cancelled {
+			return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
+				return h.PostPipelineTask(c, "close_task", pl)
+			})
+		} else {
+			return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+				return h.PostPipelineTask(c, "publish_task", pl)
+			})
+		}
+	default:
+		return &models.InvalidStateTransition{Msg: fmt.Sprintf("Unexpected Status: %v for Pipeline: %v", pl.Status, pl)}
+	}
+}

--- a/src/api/pipeline_handler_build.go
+++ b/src/api/pipeline_handler_build.go
@@ -49,7 +49,7 @@ func (h *PipelineHandler) waitBuildingTask(c echo.Context) error {
 	ctx := c.Get("aecontext").(context.Context)
 	pl := c.Get("pipeline").(*models.Pipeline)
 
-	handler := pl.RefreshHandler(ctx)
+	handler := pl.DeployingHandler(ctx)
 	refresher := &models.Refresher{}
 	err := refresher.Process(ctx, pl, handler)
 	if err != nil {

--- a/src/api/pipeline_handler_build.go
+++ b/src/api/pipeline_handler_build.go
@@ -29,8 +29,8 @@ func (h *PipelineHandler) buildTask(c echo.Context) error {
 			switch e2.Code {
 			case http.StatusConflict: // googleapi: Error 409: 'projects/optical-hangar-158902/global/deployments/pipeline-mjr-59-20170926-163820' already exists and cannot be created., duplicate
 				log.Warningf(ctx, "Skip building because of %v", e2.Message)
-				return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
-					return h.PostPipelineTask(c, "wait_building_task", pl)
+				return ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
+					return PostPipelineTask(c, "wait_building_task", pl)
 				})
 			}
 		}
@@ -38,8 +38,8 @@ func (h *PipelineHandler) buildTask(c echo.Context) error {
 		return err
 	}
 
-	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-		return h.PostPipelineTask(c, "wait_building_task", pl)
+	return ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+		return PostPipelineTask(c, "wait_building_task", pl)
 	})
 }
 
@@ -59,17 +59,17 @@ func (h *PipelineHandler) waitBuildingTask(c echo.Context) error {
 
 	switch pl.Status {
 	case models.Deploying:
-		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
-			return h.PostPipelineTaskWithETA(c, "wait_building_task", pl, started.Add(30*time.Second))
+		return ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
+			return PostPipelineTaskWithETA(c, "wait_building_task", pl, started.Add(30*time.Second))
 		})
 	case models.Opened:
 		if pl.Cancelled {
-			return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
-				return h.PostPipelineTask(c, "close_task", pl)
+			return ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
+				return PostPipelineTask(c, "close_task", pl)
 			})
 		} else {
-			return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-				return h.PostPipelineTask(c, "publish_task", pl)
+			return ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+				return PostPipelineTask(c, "publish_task", pl)
 			})
 		}
 	default:

--- a/src/api/pipeline_handler_close.go
+++ b/src/api/pipeline_handler_close.go
@@ -38,8 +38,8 @@ func (h *PipelineHandler) closeTask(c echo.Context) error {
 		return err
 	}
 
-	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-		return h.PostPipelineTask(c, "wait_closing_task", pl)
+	return ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+		return PostPipelineTask(c, "wait_closing_task", pl)
 	})
 }
 
@@ -49,7 +49,7 @@ func (h *PipelineHandler) waitClosingTask(c echo.Context) error {
 	ctx := c.Get("aecontext").(context.Context)
 	pl := c.Get("pipeline").(*models.Pipeline)
 	handler := pl.ClosingHandler(ctx, func(pl *models.Pipeline) error {
-		return h.PostPipelineTaskWith(c, "build_task", pl, url.Values{}, nil)
+		return PostPipelineTaskWith(c, "build_task", pl, url.Values{}, nil)
 	})
 
 	refresher := &models.Refresher{}
@@ -61,8 +61,8 @@ func (h *PipelineHandler) waitClosingTask(c echo.Context) error {
 
 	switch pl.Status {
 	case models.Closing:
-		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
-			return h.PostPipelineTaskWithETA(c, "wait_closing_task", pl, started.Add(30*time.Second))
+		return ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
+			return PostPipelineTaskWithETA(c, "wait_closing_task", pl, started.Add(30*time.Second))
 		})
 	case models.Closed:
 		return c.JSON(http.StatusOK, pl)

--- a/src/api/pipeline_handler_close.go
+++ b/src/api/pipeline_handler_close.go
@@ -48,7 +48,7 @@ func (h *PipelineHandler) waitClosingTask(c echo.Context) error {
 	started := time.Now()
 	ctx := c.Get("aecontext").(context.Context)
 	pl := c.Get("pipeline").(*models.Pipeline)
-	handler := pl.RefreshHandlerWith(ctx, func(pl *models.Pipeline) error {
+	handler := pl.ClosingHandler(ctx, func(pl *models.Pipeline) error {
 		return h.PostPipelineTaskWith(c, "build_task", pl, url.Values{}, nil)
 	})
 

--- a/src/api/pipeline_handler_close.go
+++ b/src/api/pipeline_handler_close.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"models"
+
+	"github.com/labstack/echo"
+	"golang.org/x/net/context"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/appengine/log"
+)
+
+// curl -v -X	POST http://localhost:8080/pipelines/1/close_task
+func (h *PipelineHandler) closeTask(c echo.Context) error {
+	ctx := c.Get("aecontext").(context.Context)
+	pl := c.Get("pipeline").(*models.Pipeline)
+	closer, err := models.NewCloser(ctx)
+	if err != nil {
+		log.Errorf(ctx, "Failed to create new closer because of %v\n", err)
+		return err
+	}
+	err = closer.Process(ctx, pl)
+	if err != nil {
+		switch err.(type) {
+		case *googleapi.Error:
+			e2 := err.(*googleapi.Error)
+			switch e2.Code {
+			case http.StatusNotFound: // googleapi: Error 404: The object 'projects/optical-hangar-158902/global/deployments/pipeline-mjr-89-20170926-223541' is not found., notFound
+				log.Warningf(ctx, "Skip closing because of %v", e2.Message)
+				return c.JSON(http.StatusOK, pl)
+			}
+		}
+		log.Errorf(ctx, "Failed to close pipeline because of %v\n", err)
+		return err
+	}
+
+	return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+		return h.PostPipelineTask(c, "wait_closing_task", pl)
+	})
+}
+
+// curl -v -X	POST http://localhost:8080/pipelines/1/wait_closing_task
+func (h *PipelineHandler) waitClosingTask(c echo.Context) error {
+	started := time.Now()
+	ctx := c.Get("aecontext").(context.Context)
+	pl := c.Get("pipeline").(*models.Pipeline)
+	handler := pl.RefreshHandlerWith(ctx, func(pl *models.Pipeline) error {
+		return h.PostPipelineTaskWith(c, "build_task", pl, url.Values{}, nil)
+	})
+
+	refresher := &models.Refresher{}
+	err := refresher.Process(ctx, pl, handler)
+	if err != nil {
+		log.Errorf(ctx, "Failed to refresh pipeline %v because of %v\n", pl, err)
+		return err
+	}
+
+	switch pl.Status {
+	case models.Closing:
+		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
+			return h.PostPipelineTaskWithETA(c, "wait_closing_task", pl, started.Add(30*time.Second))
+		})
+	case models.Closed:
+		return c.JSON(http.StatusOK, pl)
+	default:
+		return &models.InvalidStateTransition{Msg: fmt.Sprintf("Unexpected Status: %v for Pipeline: %v", pl.Status, pl)}
+	}
+}

--- a/src/api/pipeline_handler_close.go
+++ b/src/api/pipeline_handler_close.go
@@ -18,7 +18,7 @@ import (
 func (h *PipelineHandler) closeTask(c echo.Context) error {
 	ctx := c.Get("aecontext").(context.Context)
 	pl := c.Get("pipeline").(*models.Pipeline)
-	closer, err := models.NewCloser(ctx)
+	closer, err := models.NewCloser(ctx, pl.StartClosing)
 	if err != nil {
 		log.Errorf(ctx, "Failed to create new closer because of %v\n", err)
 		return err

--- a/src/api/pipeline_handler_subscribe.go
+++ b/src/api/pipeline_handler_subscribe.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"models"
+
+	"github.com/labstack/echo"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/log"
+)
+
+// curl -v -X	POST http://localhost:8080/pipelines/1/subscribe_task
+func (h *PipelineHandler) subscribeTask(c echo.Context) error {
+	started := time.Now()
+	ctx := c.Get("aecontext").(context.Context)
+	pl := c.Get("pipeline").(*models.Pipeline)
+
+	if pl.Cancelled {
+		switch pl.Status {
+		case models.Opened:
+			log.Infof(ctx, "Pipeline is cancelled.\n")
+			return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
+				return h.PostPipelineTask(c, "close_task", pl)
+			})
+		case models.Closing, models.ClosingError, models.Closed:
+			log.Warningf(ctx, "Pipeline is cancelled but do nothing because it's already closed or being closed.\n")
+			return c.JSON(http.StatusOK, pl)
+		default:
+			return &models.InvalidStateTransition{
+				Msg: fmt.Sprintf("Invalid Pipeline#Status %v to subscribe a Pipeline cancelled", pl.Status),
+			}
+		}
+	}
+
+	err := pl.PullAndUpdateJobStatus(ctx)
+	if err != nil {
+		switch err.(type) {
+		case *models.SubscriprionNotFound:
+			switch pl.Status {
+			case models.Closing, models.Closed:
+				log.Infof(ctx, "Pipeline is already closed\n")
+				return c.JSON(http.StatusOK, pl)
+			default:
+				log.Infof(ctx, "Subscription is not found but the pipeline isn't closed because of %v\n", err)
+			}
+		default:
+			log.Errorf(ctx, "Failed to get Pipeline#PullAndUpdateJobStatus() because of %v\n", err)
+			return err
+		}
+	}
+
+	jobs, err := pl.JobAccessor().All(ctx)
+	if err != nil {
+		log.Errorf(ctx, "Failed to m.JobAccessor#All() because of %v\n", err)
+		return err
+	}
+	log.Debugf(ctx, "Pipeline has %v jobs\n", len(jobs))
+
+	pendings, err := models.GlobalPipelineAccessor.PendingsFor(ctx, jobs.Finished().IDs())
+	if err != nil {
+		return err
+	}
+
+	for _, pending := range pendings {
+		org := c.Get("organization").(*models.Organization)
+		pending.Organization = org
+		err := pending.UpdateIfReserveOrWait(ctx)
+		if err != nil {
+			log.Errorf(ctx, "Failed to UpdateIfReserveOrWait pending: %v\n%v\n", pending, err)
+			return err
+		}
+		if pending.Status == models.Reserved {
+			err = h.PostPipelineTaskIfPossible(c, pending)
+			if err != nil {
+				log.Errorf(ctx, "Failed to PostPipelineTaskIfPossible pending: %v\n%v\n", pending, err)
+				return err
+			}
+		}
+	}
+
+	if jobs.AllFinished() {
+		if pl.ClosePolicy.Match(jobs) {
+			return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+				return h.PostPipelineTask(c, "close_task", pl)
+			})
+		} else {
+			return c.JSON(http.StatusOK, pl)
+		}
+	} else {
+		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
+			return h.PostPipelineTaskWithETA(c, "subscribe_task", pl, started.Add(30*time.Second))
+		})
+	}
+}

--- a/src/api/pipeline_handler_subscribe.go
+++ b/src/api/pipeline_handler_subscribe.go
@@ -22,8 +22,8 @@ func (h *PipelineHandler) subscribeTask(c echo.Context) error {
 		switch pl.Status {
 		case models.Opened:
 			log.Infof(ctx, "Pipeline is cancelled.\n")
-			return h.ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
-				return h.PostPipelineTask(c, "close_task", pl)
+			return ReturnJsonWith(c, pl, http.StatusNoContent, func() error {
+				return PostPipelineTask(c, "close_task", pl)
 			})
 		case models.Closing, models.ClosingError, models.Closed:
 			log.Warningf(ctx, "Pipeline is cancelled but do nothing because it's already closed or being closed.\n")
@@ -83,15 +83,15 @@ func (h *PipelineHandler) subscribeTask(c echo.Context) error {
 
 	if jobs.AllFinished() {
 		if pl.ClosePolicy.Match(jobs) {
-			return h.ReturnJsonWith(c, pl, http.StatusCreated, func() error {
-				return h.PostPipelineTask(c, "close_task", pl)
+			return ReturnJsonWith(c, pl, http.StatusCreated, func() error {
+				return PostPipelineTask(c, "close_task", pl)
 			})
 		} else {
 			return c.JSON(http.StatusOK, pl)
 		}
 	} else {
-		return h.ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
-			return h.PostPipelineTaskWithETA(c, "subscribe_task", pl, started.Add(30*time.Second))
+		return ReturnJsonWith(c, pl, http.StatusAccepted, func() error {
+			return PostPipelineTaskWithETA(c, "subscribe_task", pl, started.Add(30*time.Second))
 		})
 	}
 }

--- a/src/api/pipeline_handler_support.go
+++ b/src/api/pipeline_handler_support.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"models"
+
+	"github.com/labstack/echo"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/log"
+	"google.golang.org/appengine/taskqueue"
+)
+
+func (h *PipelineHandler) PostPipelineTaskWith(c echo.Context, action string, pl *models.Pipeline, params url.Values, f func(*taskqueue.Task) error) error {
+	ctx := c.Get("aecontext").(context.Context)
+	req := c.Request()
+	t := taskqueue.NewPOSTTask(fmt.Sprintf("/pipelines/%s/%s", pl.ID, action), params)
+	t.Header.Add(AUTH_HEADER, req.Header.Get(AUTH_HEADER))
+	if f != nil {
+		err := f(t)
+		if err != nil {
+			return err
+		}
+	}
+	if _, err := taskqueue.Add(ctx, t, ""); err != nil {
+		log.Errorf(ctx, "Failed to add a task %v to taskqueue because of %v\n", t, err)
+		return err
+	}
+	return nil
+}
+
+func (h *PipelineHandler) SetETAFunc(eta time.Time) func(t *taskqueue.Task) error {
+	return func(t *taskqueue.Task) error {
+		t.ETA = eta
+		return nil
+	}
+}
+
+func (h *PipelineHandler) PostPipelineTaskWithETA(c echo.Context, action string, pl *models.Pipeline, eta time.Time) error {
+	err := h.PostPipelineTaskWith(c, action, pl, url.Values{}, h.SetETAFunc(eta))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *PipelineHandler) PostPipelineTask(c echo.Context, action string, pl *models.Pipeline) error {
+	return h.PostPipelineTaskWithETA(c, action, pl, time.Now())
+}
+
+func (h *PipelineHandler) ReturnJsonWith(c echo.Context, pl *models.Pipeline, status int, f func() error) error {
+	err := f()
+	if err != nil {
+		return err
+	}
+	return c.JSON(status, pl)
+}

--- a/src/api/pipeline_handler_support.go
+++ b/src/api/pipeline_handler_support.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/appengine/taskqueue"
 )
 
-func (h *PipelineHandler) PostPipelineTaskWith(c echo.Context, action string, pl *models.Pipeline, params url.Values, f func(*taskqueue.Task) error) error {
+func PostPipelineTaskWith(c echo.Context, action string, pl *models.Pipeline, params url.Values, f func(*taskqueue.Task) error) error {
 	ctx := c.Get("aecontext").(context.Context)
 	req := c.Request()
 	t := taskqueue.NewPOSTTask(fmt.Sprintf("/pipelines/%s/%s", pl.ID, action), params)
@@ -31,26 +31,26 @@ func (h *PipelineHandler) PostPipelineTaskWith(c echo.Context, action string, pl
 	return nil
 }
 
-func (h *PipelineHandler) SetETAFunc(eta time.Time) func(t *taskqueue.Task) error {
+func SetETAFunc(eta time.Time) func(t *taskqueue.Task) error {
 	return func(t *taskqueue.Task) error {
 		t.ETA = eta
 		return nil
 	}
 }
 
-func (h *PipelineHandler) PostPipelineTaskWithETA(c echo.Context, action string, pl *models.Pipeline, eta time.Time) error {
-	err := h.PostPipelineTaskWith(c, action, pl, url.Values{}, h.SetETAFunc(eta))
+func PostPipelineTaskWithETA(c echo.Context, action string, pl *models.Pipeline, eta time.Time) error {
+	err := PostPipelineTaskWith(c, action, pl, url.Values{}, SetETAFunc(eta))
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (h *PipelineHandler) PostPipelineTask(c echo.Context, action string, pl *models.Pipeline) error {
-	return h.PostPipelineTaskWithETA(c, action, pl, time.Now())
+func PostPipelineTask(c echo.Context, action string, pl *models.Pipeline) error {
+	return PostPipelineTaskWithETA(c, action, pl, time.Now())
 }
 
-func (h *PipelineHandler) ReturnJsonWith(c echo.Context, pl *models.Pipeline, status int, f func() error) error {
+func ReturnJsonWith(c echo.Context, pl *models.Pipeline, status int, f func() error) error {
 	err := f()
 	if err != nil {
 		return err

--- a/src/models/job.go
+++ b/src/models/job.go
@@ -160,7 +160,13 @@ func (m *Job) Key(ctx context.Context) (*datastore.Key, error) {
 	if err != nil {
 		return nil, err
 	}
-	key := datastore.NewKey(ctx, "Jobs", m.IdByClient, 0, parentKey)
+	var key *datastore.Key
+	if m.IdByClient == "" {
+		key = datastore.NewIncompleteKey(ctx, "Jobs", parentKey)
+		m.IdByClient = "Generated:" + key.Encode()
+	} else {
+		key = datastore.NewKey(ctx, "Jobs", m.IdByClient, 0, parentKey)
+	}
 	return key, nil
 }
 

--- a/src/models/job.go
+++ b/src/models/job.go
@@ -218,7 +218,7 @@ func (m *Job) LoadOrCreate(ctx context.Context) error {
 		case datastore.ErrNoSuchEntity:
 			return m.Create(ctx)
 		default:
-			log.Errorf(ctx, "JobAccessor#Find %v id: %q\n", err, id)
+			log.Errorf(ctx, "Failed at LoadOrCreate %v id: %q\n", err, id)
 			return err
 		}
 	}, GetTransactionOptions(ctx))

--- a/src/models/job.go
+++ b/src/models/job.go
@@ -204,29 +204,39 @@ func (m *Job) Create(ctx context.Context) error {
 	return nil
 }
 
+func (m *Job) LoadBy(ctx context.Context, key *datastore.Key) error {
+	tmp := &Job{}
+	err := datastore.Get(ctx, key, tmp)
+	if err == nil {
+		m.CopyFrom(tmp)
+		m.ID = key.Encode()
+		msg := &m.Message
+		msg.EntriesToMap()
+		return nil
+	}
+	return err
+}
+
 func (m *Job) LoadOrCreate(ctx context.Context) error {
 	return datastore.RunInTransaction(ctx, func(ctx context.Context) error {
 		key, err := m.Key(ctx)
 		if err != nil {
 			return err
 		}
-		id := key.Encode()
-		tmp := &Job{}
-		err = datastore.Get(ctx, key, tmp)
-		if err == nil {
-			m.CopyFrom(tmp)
-			m.ID = id
-			msg := &m.Message
-			msg.EntriesToMap()
-			return nil
+		if !key.Incomplete() {
+			err := m.LoadBy(ctx, key)
+			if err == nil {
+				return nil
+			}
+			switch err {
+			case datastore.ErrNoSuchEntity:
+				// Create later
+			default:
+				log.Errorf(ctx, "Failed at LoadBy %v id: %q\n", err, key.Encode())
+				return err
+			}
 		}
-		switch err {
-		case datastore.ErrNoSuchEntity:
-			return m.Create(ctx)
-		default:
-			log.Errorf(ctx, "Failed at LoadOrCreate %v id: %q\n", err, id)
-			return err
-		}
+		return m.Create(ctx)
 	}, GetTransactionOptions(ctx))
 }
 

--- a/src/models/job_accessor.go
+++ b/src/models/job_accessor.go
@@ -20,7 +20,7 @@ func (aa *JobAccessor) Find(ctx context.Context, id string) (*Job, error) {
 	// log.Debugf(ctx, "JobAccessor#Find id: %q\n", id)
 	key, err := datastore.DecodeKey(id)
 	if err != nil {
-		log.Errorf(ctx, "JobAccessor#Find %v id: %q\n", err, id)
+		log.Errorf(ctx, "Failed to DecodeKey at JobAccessor#Find %v id: %q\n", err, id)
 		return nil, err
 	}
 	if aa.Parent != nil {
@@ -39,7 +39,7 @@ func (aa *JobAccessor) Find(ctx context.Context, id string) (*Job, error) {
 	case err == datastore.ErrNoSuchEntity:
 		return nil, ErrNoSuchJob
 	case err != nil:
-		log.Errorf(ctx, "JobAccessor#Find %v id: %q\n", err, id)
+		log.Errorf(ctx, "Failed to Get at JobAccessor#Find %v id: %q\n", err, id)
 		return nil, err
 	}
 	msg := &m.Message

--- a/src/models/organization.go
+++ b/src/models/organization.go
@@ -85,3 +85,19 @@ func (m *Organization) AuthAccessor() *AuthAccessor {
 func (m *Organization) PipelineAccessor() *PipelineAccessor {
 	return &PipelineAccessor{Parent: m}
 }
+
+func (m *Organization) GetBackToken(ctx context.Context, pl Pipeline, handler func() error) error {
+	newTokenAmount := m.TokenAmount + pl.TokenConsumption
+	if handler != nil {
+		err := handler()
+		if err != nil {
+			return err
+		}
+	}
+	m.TokenAmount = newTokenAmount
+	err = m.Update(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/models/organization.go
+++ b/src/models/organization.go
@@ -86,18 +86,43 @@ func (m *Organization) PipelineAccessor() *PipelineAccessor {
 	return &PipelineAccessor{Parent: m}
 }
 
-func (m *Organization) GetBackToken(ctx context.Context, pl Pipeline, handler func() error) error {
-	newTokenAmount := m.TokenAmount + pl.TokenConsumption
+func (m *Organization) GetBackToken(ctx context.Context, pl *Pipeline, handler func() error) error {
+	m.TokenAmount = m.TokenAmount + pl.TokenConsumption
 	if handler != nil {
 		err := handler()
 		if err != nil {
 			return err
 		}
 	}
-	m.TokenAmount = newTokenAmount
-	err = m.Update(ctx)
+	err := m.Update(ctx)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func (m *Organization) StartWaitingPipelines(ctx context.Context, handler func(*Pipeline) error) error {
+	waitings, err := m.PipelineAccessor().GetWaitings(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, waiting := range waitings {
+		if m.TokenAmount < waiting.TokenConsumption {
+			return nil
+		}
+		m.TokenAmount = m.TokenAmount - waiting.TokenConsumption
+		waiting.Status = Reserved
+		err := waiting.Update(ctx)
+		if err != nil {
+			return err
+		}
+		if handler != nil {
+			err := handler(waiting)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/src/models/pipeline.go
+++ b/src/models/pipeline.go
@@ -572,6 +572,7 @@ func (m *Pipeline) stringFromMapWithDefault(src map[string]string, key, defaultV
 }
 
 func (m *Pipeline) AddActionLog(ctx context.Context, name string) {
+	log.Debugf(ctx, "pipeline is %v\n", name)
 	if m.ActionLogs == nil {
 		m.ActionLogs = []ActionLog{}
 	}

--- a/src/models/pipeline.go
+++ b/src/models/pipeline.go
@@ -572,7 +572,9 @@ func (m *Pipeline) stringFromMapWithDefault(src map[string]string, key, defaultV
 }
 
 func (m *Pipeline) AddActionLog(ctx context.Context, name string) {
-	log.Debugf(ctx, "pipeline is %v\n", name)
+	if ctx != nil {
+		log.Debugf(ctx, "pipeline is %v\n", name)
+	}
 	if m.ActionLogs == nil {
 		m.ActionLogs = []ActionLog{}
 	}

--- a/src/models/pipeline.go
+++ b/src/models/pipeline.go
@@ -322,26 +322,6 @@ func (m *Pipeline) RefreshHandler(ctx context.Context, pipelineProcesser func(*P
 	}
 }
 
-func (m *Pipeline) DeployingHandler(ctx context.Context) func(*[]DeploymentError) error {
-	return func(errors *[]DeploymentError) error {
-		if errors != nil {
-			return m.FailDeploying(ctx, errors)
-		} else {
-			return m.CompleteDeploying(ctx)
-		}
-	}
-}
-
-func (m *Pipeline) ClosingHandler(ctx context.Context, pipelineProcesser func(*Pipeline) error) func(*[]DeploymentError) error {
-	return func(errors *[]DeploymentError) error {
-		if errors != nil {
-			return m.FailClosing(ctx, errors)
-		} else {
-			return m.CompleteClosing(ctx, pipelineProcesser)
-		}
-	}
-}
-
 func (m *Pipeline) StateTransition(ctx context.Context, froms []Status, to Status) error {
 	allowed := false
 	for _, from := range froms {
@@ -379,6 +359,16 @@ func (m *Pipeline) CompleteDeploying(ctx context.Context) error {
 	return m.StateTransition(ctx, []Status{Deploying}, Opened)
 }
 
+func (m *Pipeline) DeployingHandler(ctx context.Context) func(*[]DeploymentError) error {
+	return func(errors *[]DeploymentError) error {
+		if errors != nil {
+			return m.FailDeploying(ctx, errors)
+		} else {
+			return m.CompleteDeploying(ctx)
+		}
+	}
+}
+
 func (m *Pipeline) StartClosing(ctx context.Context, operationName string) error {
 	m.AddActionLog(ctx, "close-started")
 	m.ClosingOperationName = operationName
@@ -411,6 +401,16 @@ func (m *Pipeline) CompleteClosing(ctx context.Context, pipelineProcesser func(*
 
 		return m.StateTransition(ctx, []Status{Closing}, Closed)
 	}, GetTransactionOptions(ctx))
+}
+
+func (m *Pipeline) ClosingHandler(ctx context.Context, pipelineProcesser func(*Pipeline) error) func(*[]DeploymentError) error {
+	return func(errors *[]DeploymentError) error {
+		if errors != nil {
+			return m.FailClosing(ctx, errors)
+		} else {
+			return m.CompleteClosing(ctx, pipelineProcesser)
+		}
+	}
 }
 
 func (m *Pipeline) CancelLivingJobs(ctx context.Context) error {

--- a/src/models/pipeline.go
+++ b/src/models/pipeline.go
@@ -411,28 +411,7 @@ func (m *Pipeline) CompleteClosing(ctx context.Context, pipelineProcesser func(*
 		}
 
 		org.GetBackToken(ctx, m, func() error {
-			waitings, err := org.PipelineAccessor().GetWaitings(ctx)
-			if err != nil {
-				return err
-			}
-
-			for _, waiting := range waitings {
-				if newTokenAmount < waiting.TokenConsumption {
-					break
-				}
-				newTokenAmount = newTokenAmount - waiting.TokenConsumption
-				waiting.Status = Reserved
-				err := waiting.Update(ctx)
-				if err != nil {
-					return err
-				}
-				if pipelineProcesser != nil {
-					err := pipelineProcesser(waiting)
-					if err != nil {
-						return err
-					}
-				}
-			}
+			return org.StartWaitingPipelines(ctx, pipelineProcesser)
 		})
 
 		return m.StateTransition(ctx, []Status{Closing}, Closed)

--- a/src/models/pipeline.go
+++ b/src/models/pipeline.go
@@ -362,9 +362,6 @@ func (m *Pipeline) StartBuilding(ctx context.Context) error {
 	return m.StateTransition(ctx, []Status{Reserved, Building}, Building)
 }
 
-func (m *Pipeline) FinishBuilding(ctx context.Context) {
-}
-
 func (m *Pipeline) StartDeploying(ctx context.Context, deploymentName, operationName string) error {
 	m.DeploymentName = deploymentName
 	m.DeployingOperationName = operationName

--- a/src/models/pipeline.go
+++ b/src/models/pipeline.go
@@ -390,19 +390,9 @@ func (m *Pipeline) CompleteClosing(ctx context.Context, pipelineProcesser func(*
 	m.AddActionLog(ctx, "close-finished")
 	m.Update(ctx)
 	return datastore.RunInTransaction(ctx, func(ctx context.Context) error {
-		accessor := m.JobAccessor()
-		jobs, err := accessor.All(ctx)
+		err := m.CancelLivingJobs(ctx)
 		if err != nil {
 			return err
-		}
-		for _, job := range jobs {
-			if job.Status.Living() {
-				job.Status = Cancelled
-				err = job.Update(ctx)
-				if err != nil {
-					return err
-				}
-			}
 		}
 
 		org, err := GlobalOrganizationAccessor.Find(ctx, m.Organization.ID)
@@ -416,6 +406,24 @@ func (m *Pipeline) CompleteClosing(ctx context.Context, pipelineProcesser func(*
 
 		return m.StateTransition(ctx, []Status{Closing}, Closed)
 	}, GetTransactionOptions(ctx))
+}
+
+func (m *Pipeline) CancelLivingJobs(ctx context.Context) error {
+	accessor := m.JobAccessor()
+	jobs, err := accessor.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		if job.Status.Living() {
+			job.Status = Cancelled
+			err = job.Update(ctx)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (m *Pipeline) Cancel(ctx context.Context) error {

--- a/src/models/pipeline.go
+++ b/src/models/pipeline.go
@@ -409,36 +409,31 @@ func (m *Pipeline) CompleteClosing(ctx context.Context, pipelineProcesser func(*
 		if err != nil {
 			return err
 		}
-		newTokenAmount := org.TokenAmount + m.TokenConsumption
 
-		waitings, err := org.PipelineAccessor().GetWaitings(ctx)
-		if err != nil {
-			return err
-		}
-
-		for _, waiting := range waitings {
-			if newTokenAmount < waiting.TokenConsumption {
-				break
-			}
-			newTokenAmount = newTokenAmount - waiting.TokenConsumption
-			waiting.Status = Reserved
-			err := waiting.Update(ctx)
+		org.GetBackToken(ctx, m, func() error {
+			waitings, err := org.PipelineAccessor().GetWaitings(ctx)
 			if err != nil {
 				return err
 			}
-			if pipelineProcesser != nil {
-				err := pipelineProcesser(waiting)
+
+			for _, waiting := range waitings {
+				if newTokenAmount < waiting.TokenConsumption {
+					break
+				}
+				newTokenAmount = newTokenAmount - waiting.TokenConsumption
+				waiting.Status = Reserved
+				err := waiting.Update(ctx)
 				if err != nil {
 					return err
 				}
+				if pipelineProcesser != nil {
+					err := pipelineProcesser(waiting)
+					if err != nil {
+						return err
+					}
+				}
 			}
-		}
-
-		org.TokenAmount = newTokenAmount
-		err = org.Update(ctx)
-		if err != nil {
-			return err
-		}
+		})
 
 		return m.StateTransition(ctx, []Status{Closing}, Closed)
 	}, GetTransactionOptions(ctx))

--- a/src/models/refresher.go
+++ b/src/models/refresher.go
@@ -31,7 +31,7 @@ func (b *Refresher) Setup(ctx context.Context, pl *Pipeline) error {
 }
 
 func (b *Refresher) Process(ctx context.Context, pl *Pipeline, handler func(*[]DeploymentError) error) error {
-	log.Debugf(ctx, "Refreshing pipeline %v\n", pl)
+	log.Debugf(ctx, "Refreshing %v pipeline %v \n", pl.Status, pl.Name)
 
 	switch pl.Status {
 	case Deploying, Closing:

--- a/src/models/refresher_test.go
+++ b/src/models/refresher_test.go
@@ -133,7 +133,7 @@ func TestRefresherProcessForDeploying(t *testing.T) {
 		err = pl.Create(ctx)
 
 		r := &Refresher{deployer: expection.deployer}
-		err = r.Process(ctx, pl, pl.RefreshHandler(ctx))
+		err = r.Process(ctx, pl, pl.RefreshHandler(ctx, nil))
 		assert.NoError(t, err)
 		pl2, err := GlobalPipelineAccessor.Find(ctx, pl.ID)
 		assert.NoError(t, err)
@@ -214,7 +214,7 @@ func TestRefresherProcessForClosing(t *testing.T) {
 		assert.NoError(t, err)
 
 		r := &Refresher{deployer: expection.deployer}
-		err = r.Process(ctx, pl, pl.RefreshHandler(ctx))
+		err = r.Process(ctx, pl, pl.RefreshHandler(ctx, nil))
 		assert.NoError(t, err)
 		pl2, err := GlobalPipelineAccessor.Find(ctx, pl.ID)
 		assert.NoError(t, err)


### PR DESCRIPTION
This PR is for #67 .

Add a lot of refactorings:

- Split big `src/api/pipeline_handler.go` to several files
- Extract `ReturnJsonWith ` method from some support methods
    -  So`PostPipelineTask ` and `PostPipelineTaskWithETA` doesn't request `status` argument, 
- Make support methods global
- Extract `Organization` methods `#GetBackToken` and `#StartWaitingPipelines`
- Extract `Pipeline` methods `DeployingHandler` and `ClosingHandler`
- `Closer` struct takes `Handler` to dispatch handling `Pipeline` status like `Refresher`

## Some features

- Allow empty `id_by_client` 
    - It will be generated if not given
- Improve log messages
