### PR TITLE
Fix JobHandler routings

### DIFF
--- a/src/api/routes.go
+++ b/src/api/routes.go
@@ -70,9 +70,8 @@ func SetupRoutesOfJobs() *JobHandler {
 	g.GET("", h.index)
 	g.POST("", h.create)
 
-	g = e.Group("/pipelines/:pipeline_id", h.collection)
-	g.POST("/bulk_get_jobs", h.BulkGetJobs)
-	g.POST("/bulk_job_statuses", h.BulkJobStatuses)
+	e.POST("/pipelines/:pipeline_id/bulk_get_jobs", h.BulkGetJobs, h.collection)
+	e.POST("/pipelines/:pipeline_id/bulk_job_statuses", h.BulkJobStatuses, h.collection)
 
 	g = e.Group("/jobs", h.member)
 	g.GET("/:id", h.show)

--- a/src/api/routes.go
+++ b/src/api/routes.go
@@ -30,10 +30,11 @@ func SetupRoutesOfPipelines() *PipelineHandler {
 	g.GET("/:id", h.show)
 	g.PUT("/:id/cancel", h.cancel)
 	g.PUT("/:id/close", h.cancel)
+	g.DELETE("/:id", h.destroy)
+
 	g.POST("/:id/close_task", h.closeTask)
 	g.POST("/:id/check_hibernation_task", h.checkHibernationTask)
 	g.POST("/:id/hibernate_task", h.hibernateTask)
-	g.DELETE("/:id", h.destroy)
 
 	g.POST("/:id/build_task", h.buildTask)
 	g.POST("/:id/publish_task", h.publishTask)
@@ -75,9 +76,10 @@ func SetupRoutesOfJobs() *JobHandler {
 	g = e.Group("/jobs", h.member)
 	g.GET("/:id", h.show)
 	g.POST("/:id/getready", h.getReady)
+	g.POST("/:id/cancel", h.Cancel)
+
 	g.POST("/:id/wait_task", h.WaitToPublishTask)
 	g.POST("/:id/publish_task", h.PublishTask)
-	g.POST("/:id/cancel", h.Cancel)
 
 	return h
 }

--- a/src/api/routes.go
+++ b/src/api/routes.go
@@ -32,6 +32,7 @@ func SetupRoutesOfPipelines() *PipelineHandler {
 	g.PUT("/:id/close", h.cancel)
 	g.DELETE("/:id", h.destroy)
 
+	g = e.Group("/pipelines", h.member)
 	g.POST("/:id/close_task", h.closeTask)
 	g.POST("/:id/check_hibernation_task", h.checkHibernationTask)
 	g.POST("/:id/hibernate_task", h.hibernateTask)
@@ -78,6 +79,7 @@ func SetupRoutesOfJobs() *JobHandler {
 	g.POST("/:id/getready", h.getReady)
 	g.POST("/:id/cancel", h.Cancel)
 
+	g = e.Group("/jobs", h.member)
 	g.POST("/:id/wait_task", h.WaitToPublishTask)
 	g.POST("/:id/publish_task", h.PublishTask)
 


### PR DESCRIPTION
The JobHandler for `POST /pipelines/:pipeline_id/bulk_get_jobs` and `POST /pipelines/:pipeline_id/bulk_job_statuses` was conflicted with the PipelineHandler for `/pipelines/:id` .
So this PR fix the definitions for JobHandler.